### PR TITLE
Fix MSVC runtime checks interop to unbreak CI

### DIFF
--- a/src/x86/ffi.c
+++ b/src/x86/ffi.c
@@ -258,6 +258,13 @@ static const struct abi_params abi_params[FFI_LAST_ABI] = {
 
 extern void FFI_DECLARE_FASTCALL ffi_call_i386(struct call_frame *, char *) FFI_HIDDEN;
 
+/* We perform some black magic here to use some of the parent's stack frame in
+ * ffi_call_i386() that breaks with the MSVC compiler with the /RTCs or /GZ
+ * flags.  Disable the 'Stack frame run time error checking' for this function
+ * so we don't hit weird exceptions in debug builds. */
+#if defined(_MSC_VER)
+#pragma runtime_checks("s", off)
+#endif
 static void
 ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
 	      void **avalue, void *closure)
@@ -393,6 +400,9 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
 
   ffi_call_i386 (frame, stack);
 }
+#if defined(_MSC_VER)
+#pragma runtime_checks("s", restore)
+#endif
 
 void
 ffi_call (ffi_cif *cif, void (*fn)(void), void *rvalue, void **avalue)

--- a/src/x86/ffiw64.c
+++ b/src/x86/ffiw64.c
@@ -108,6 +108,13 @@ EFI64(ffi_prep_cif_machdep)(ffi_cif *cif)
   return FFI_OK;
 }
 
+/* We perform some black magic here to use some of the parent's stack frame in
+ * ffi_call_win64() that breaks with the MSVC compiler with the /RTCs or /GZ
+ * flags.  Disable the 'Stack frame run time error checking' for this function
+ * so we don't hit weird exceptions in debug builds. */
+#if defined(_MSC_VER)
+#pragma runtime_checks("s", off)
+#endif
 static void
 ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
 	      void **avalue, void *closure)
@@ -172,6 +179,9 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
 
   ffi_call_win64 (stack, frame, closure);
 }
+#if defined(_MSC_VER)
+#pragma runtime_checks("s", restore)
+#endif
 
 void
 EFI64(ffi_call)(ffi_cif *cif, void (*fn)(void), void *rvalue, void **avalue)


### PR DESCRIPTION
## Description

In an [unrelated-to-FFI PHP PR](https://github.com/php/php-src/pull/10624) the CI consistently breaks on 4 FFI tests. It turns out that the FFI test failures are unrelated to my PR, but are caused by the MSVC runtime checks thinking there is a stack corruption. This is a false positive warning that was fixed upstream in libffi upstream in 2021: https://github.com/libffi/libffi/commit/f88add14e40de398706c732e578620e8106062c7. I cherry-picked this patch in this PR.
Before this patch, I can trigger the test failures on a Windows VM with PHP-8.1+. After applying the patch they no longer trigger.

Relevant PHP comments:
https://github.com/php/php-src/pull/10624#issuecomment-1440825774
https://github.com/php/php-src/pull/10624#issuecomment-1440833196

## Cherry-picked commit description:

MSVC can add runtime code that checks if a stack frame is mismanaged, however our custom assembly deliberately accesses and modifies the parent stack frame.  Fortunately we can disable that specific check for the function call so do that.